### PR TITLE
Kafka Max Connectors Fix

### DIFF
--- a/jikkou/kafka-connectors-template.jinja
+++ b/jikkou/kafka-connectors-template.jinja
@@ -12,7 +12,7 @@ metadata:
     kafka.jikkou.io/connect-cluster: {{ values.clusterName }}
 spec:
   connectorClass: {{ system.env.KAFKA_CONNECT_CONNECTOR_CLASS | default(values.connectorClass) }}
-  tasksMax: {{ system.env.KAFKA_TOPIC_PARTITIONS | default(values.tasksMax) }}
+  tasksMax: {{ system.env.CONNECT_TASKS_MAX | default(values.tasksMax) }}
   config:
     collection: {{ connector.collectionName }}
     connection.uri: mongodb://{{ system.env.MONGO_CONNECTOR_USERNAME }}:{{ system.env.MONGO_CONNECTOR_PASSWORD }}@{{ system.env.MONGO_DB_IP }}:27017/


### PR DESCRIPTION
Changes the max tasks to be based off of the CONNECT_TASKS_MAX env var