### PR TITLE
Update Intersection API Topic and Collection Names

### DIFF
--- a/jikkou/kafka-connectors-values.yaml
+++ b/jikkou/kafka-connectors-values.yaml
@@ -150,12 +150,12 @@ apps:
     name: conflictmonitor
     connectors:
       # Record Events
-      - topicName: topic.CmSignalStateEvent
-        collectionName: CmSignalStateEvent
+      - topicName: topic.StopLinePassageEvent
+        collectionName: StopLinePassageEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
-      - topicName: topic.CmSignalStateStopEvent
-        collectionName: CmSignalStateStopEvent
+      - topicName: topic.StopLineStopEvent
+        collectionName: StopLineStopEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
       - topicName: topic.CmSignalStateConflictEvents
@@ -275,12 +275,12 @@ apps:
         collectionName: CmConnectionOfTravelAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
-      - topicName: topic.CmSignalStateEventAssessment
-        collectionName: CmSignalStateEventAssessment
+      - topicName: topic.StopLinePassageAssessment
+        collectionName: StopLinePassageAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
-      - topicName: topic.CmStopLineStopAssessment
-        collectionName: CmStopLineStopAssessment
+      - topicName: topic.StopLineStopAssessment
+        collectionName: StopLineStopAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
       

--- a/jikkou/kafka-connectors-values.yaml
+++ b/jikkou/kafka-connectors-values.yaml
@@ -150,12 +150,12 @@ apps:
     name: conflictmonitor
     connectors:
       # Record Events
-      - topicName: topic.CmStopLinePassageEvent
-        collectionName: CmStopLinePassageEvent
+      - topicName: topic.CmSignalStateEvent
+        collectionName: CmSignalStateEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
-      - topicName: topic.CmStopLineStopEvent
-        collectionName: CmStopLineStopEvent
+      - topicName: topic.CmSignalStateStopEvent
+        collectionName: CmSignalStateStopEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
       - topicName: topic.CmSignalStateConflictEvents

--- a/jikkou/kafka-connectors-values.yaml
+++ b/jikkou/kafka-connectors-values.yaml
@@ -150,12 +150,12 @@ apps:
     name: conflictmonitor
     connectors:
       # Record Events
-      - topicName: topic.StopLinePassageEvent
-        collectionName: StopLinePassageEvent
+      - topicName: topic.CmStopLinePassageEvent
+        collectionName: CmStopLinePassageEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
-      - topicName: topic.StopLineStopEvent
-        collectionName: StopLineStopEvent
+      - topicName: topic.CmStopLineStopEvent
+        collectionName: CmStopLineStopEvent
         useTimestamp: true
         timestampField: eventGeneratedAt
       - topicName: topic.CmSignalStateConflictEvents
@@ -275,12 +275,12 @@ apps:
         collectionName: CmConnectionOfTravelAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
-      - topicName: topic.StopLinePassageAssessment
-        collectionName: StopLinePassageAssessment
+      - topicName: topic.CmStopLinePassageAssessment
+        collectionName: CmStopLinePassageAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
-      - topicName: topic.StopLineStopAssessment
-        collectionName: StopLineStopAssessment
+      - topicName: topic.CmStopLineStopAssessment
+        collectionName: CmStopLineStopAssessment
         useTimestamp: true
         timestampField: assessmentGeneratedAt
       

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -105,8 +105,8 @@ apps:
       - topic.CmBsmEvents
       - topic.CmConnectionOfTravelEvent
       - topic.CmLaneDirectionOfTravelEvent
-      - topic.CmStopLinePassageEvent
-      - topic.CmStopLineStopEvent
+      - topic.CmSignalStateEvent
+      - topic.CmSignalStateStopEvent
       - topic.CmSpatTimeChangeDetailsEvent
       - topic.CmSignalGroupAlignmentEvents
       - topic.CmIntersectionReferenceAlignmentEvents

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -105,8 +105,8 @@ apps:
       - topic.CmBsmEvents
       - topic.CmConnectionOfTravelEvent
       - topic.CmLaneDirectionOfTravelEvent
-      - topic.StopLinePassageEvent
-      - topic.StopLineStopEvent
+      - topic.CmStopLinePassageEvent
+      - topic.CmStopLineStopEvent
       - topic.CmSpatTimeChangeDetailsEvent
       - topic.CmSignalGroupAlignmentEvents
       - topic.CmIntersectionReferenceAlignmentEvents
@@ -147,9 +147,9 @@ apps:
       - topic.CmMapBoundingBox
       - topic.CmEvent
       - topic.CmAssessment
-      - topic.StopLineStopAssessment
+      - topic.CmStopLineStopAssessment
       - topic.CmStopLineStopNotification
-      - topic.StopLinePassageAssessment
+      - topic.CmStopLinePassageAssessment
       - topic.CmStopLinePassageNotification
       - topic.CmMapRevisionCounterEvents
       - topic.CmSpatRevisionCounterEvents

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -105,8 +105,8 @@ apps:
       - topic.CmBsmEvents
       - topic.CmConnectionOfTravelEvent
       - topic.CmLaneDirectionOfTravelEvent
-      - topic.CmSignalStateEvent
-      - topic.CmSignalStateStopEvent
+      - topic.StopLinePassageEvent
+      - topic.StopLineStopEvent
       - topic.CmSpatTimeChangeDetailsEvent
       - topic.CmSignalGroupAlignmentEvents
       - topic.CmIntersectionReferenceAlignmentEvents
@@ -147,9 +147,9 @@ apps:
       - topic.CmMapBoundingBox
       - topic.CmEvent
       - topic.CmAssessment
-      - topic.CmStopLineStopAssessment
+      - topic.StopLineStopAssessment
       - topic.CmStopLineStopNotification
-      - topic.CmSignalStateEventAssessment
+      - topic.StopLinePassageAssessment
       - topic.CmStopLinePassageNotification
       - topic.CmMapRevisionCounterEvents
       - topic.CmSpatRevisionCounterEvents

--- a/mongo/create_indexes.js
+++ b/mongo/create_indexes.js
@@ -95,8 +95,8 @@ const geoJsonConverterCollections = [
 const conflictMonitorCollections = [
     // Conflict Monitor Events
     //{ name: "CmEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds }, redundant - enable as needed
-    { name: "CmStopLineStopEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
-    { name: "CmStopLinePassageEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmSignalStateStopEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmSignalStateEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmIntersectionReferenceAlignmentEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmSignalGroupAlignmentEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmConnectionOfTravelEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },

--- a/mongo/create_indexes.js
+++ b/mongo/create_indexes.js
@@ -95,8 +95,8 @@ const geoJsonConverterCollections = [
 const conflictMonitorCollections = [
     // Conflict Monitor Events
     //{ name: "CmEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds }, redundant - enable as needed
-    { name: "CmSignalStateStopEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
-    { name: "CmSignalStateEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmStopLineStopEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmStopLinePassageEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmIntersectionReferenceAlignmentEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmSignalGroupAlignmentEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmConnectionOfTravelEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
@@ -137,7 +137,7 @@ const conflictMonitorCollections = [
     //{ name: "CmAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds }, redundant - enable as needed
     { name: "CmLaneDirectionOfTravelAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmConnectionOfTravelAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
-    { name: "CmSignalStateEventAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmStopLinePassageAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmStopLineStopAssessment", ttlField: "assessmentGeneratedAt", timeField: "assessmentGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     
     // Conflict Monitor Notifications


### PR DESCRIPTION
Updates the CV Manager Intersection API's Kafka topic and MongoDB collection names based on the newly named event types.

The following events have been renamed:
- CmStopLineStopEvent -> CmSignalStateStopEvent
- CmStopLinePassageEvent -> CmSignalStateEvent