### PR TITLE
Revocable Lane Algorithm Support

### DIFF
--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -130,6 +130,8 @@ apps:
       - topic.CmBsmMessageCountProgressionEventAggregation
       - topic.CmMapMessageCountProgressionEventAggregation
       - topic.CmSpatMessageCountProgressionEventAggregation
+      - topic.CmRevocableEnabledLaneAlignment
+      - topic.CmRevocableEnabledLaneAlignmentEventAggregation
     tableTopics:
       - topic.CmLaneDirectionOfTravelNotification
       - topic.CmConnectionOfTravelNotification

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -159,11 +159,13 @@ apps:
       - topic.CmTimestampDeltaNotification
       - topic.CmSpatTransitionNotification
       - topic.CmEventStateProgressionNotification
+      - topic.CmRevocableEnabledLaneAlignmentNotification
       - topic.CmIntersectionReferenceAlignmentNotificationAggregation
       - topic.CmSignalGroupAlignmentNotificationAggregation
       - topic.CmSignalStateConflictNotificationAggregation
       - topic.CmSpatTimeChangeDetailsNotificationAggregation
       - topic.CmEventStateProgressionNotificationAggregation
+      - topic.CmRevocableEnabledLaneAlignmentNotificationAggregation
       
     customTopics: {}
   deduplicator:


### PR DESCRIPTION
Add Kafka topics needed by the CIMMS Revocable/Enabled Lane Alignment algorithm.