### PR TITLE
Adding Connectors and Indexes for Revocable Lanes

### DIFF
--- a/jikkou/kafka-connectors-values.yaml
+++ b/jikkou/kafka-connectors-values.yaml
@@ -239,6 +239,10 @@ apps:
         collectionName: CmBsmMessageCountProgressionEvents
         useTimestamp: true
         timestampField: eventGeneratedAt
+      - topicName: topic.CmRevocableEnabledLaneAlignmentEvent
+        collectionName: CmRevocableEnabledLaneAlignmentEvent
+        useTimestamp: true
+        timestampField: eventGeneratedAt
       - topicName: topic.CmSpatMinimumDataEventAggregation
         collectionName: CmSpatMinimumDataEventAggregation
         generateTimestamp: true
@@ -279,6 +283,12 @@ apps:
         collectionName: CmSpatMessageCountProgressionEventAggregation
         generateTimestamp: true
         timestampField: eventGeneratedAt
+      - topicName: topic.CmRevocableEnabledLaneAlignmentEventAggregation
+        collectionName: CmRevocableEnabledLaneAlignmentEventAggregation
+        generateTimestamp: true
+        timestampField: eventGeneratedAt
+
+
 
       # Record BSM events:
       - topicName: topic.CmBsmEvents
@@ -363,6 +373,10 @@ apps:
         collectionName: CmEventStateProgressionNotification
         generateTimestamp: true
         timestampField: eventGeneratedAt
+      - topicName: topic.CmRevocableEnabledLaneAlignmentNotification
+        collectionName: CmRevocableEnabledLaneAlignmentNotification
+        generateTimestamp: true
+        timestampField: eventGeneratedAt
       - topicName: topic.CmIntersectionReferenceAlignmentNotificationAggregation
         collectionName: CmIntersectionReferenceAlignmentNotificationAggregation
         generateTimestamp: true
@@ -383,6 +397,11 @@ apps:
         collectionName: CmEventStateProgressionNotificationAggregation
         generateTimestamp: true
         timestampField: notificationGeneratedAt
+      - topicName: topic.CmRevocableEnabledLaneAlignmentNotificationAggregation
+        collectionName: CmRevocableEnabledLaneAlignmentNotificationAggregation
+        generateTimestamp: true
+        timestampField: notificationGeneratedAt
+      
   mecdeposit:
     name: mecdeposit
     connectors:

--- a/jikkou/kafka-topics-values.yaml
+++ b/jikkou/kafka-topics-values.yaml
@@ -113,6 +113,7 @@ apps:
       - topic.CmMapMessageCountProgressionEvents
       - topic.CmSpatMessageCountProgressionEvents
       - topic.CmEventStateProgressionEvent
+      - topic.CmRevocableEnabledLaneAlignmentEvent
       - topic.CmSpatMinimumDataEventAggregation
       - topic.CmMapMinimumDataEventAggregation
       - topic.CmIntersectionReferenceAlignmentEventAggregation
@@ -123,7 +124,6 @@ apps:
       - topic.CmBsmMessageCountProgressionEventAggregation
       - topic.CmMapMessageCountProgressionEventAggregation
       - topic.CmSpatMessageCountProgressionEventAggregation
-      - topic.CmRevocableEnabledLaneAlignment
       - topic.CmRevocableEnabledLaneAlignmentEventAggregation
     tableTopics:
       - topic.CmLaneDirectionOfTravelNotification

--- a/mongo/create_indexes.js
+++ b/mongo/create_indexes.js
@@ -119,6 +119,7 @@ const conflictMonitorCollections = [
     { name: "CmSpatMessageCountProgressionEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmMapMessageCountProgressionEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmBsmMessageCountProgressionEvents", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmRevocableEnabledLaneAlignmentEvent", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
 
     { name: "CmSpatMinimumDataEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmMapMinimumDataEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
@@ -131,7 +132,7 @@ const conflictMonitorCollections = [
     { name: "CmBsmMessageCountProgressionEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmMapMessageCountProgressionEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmSpatMessageCountProgressionEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
-
+    { name: "CmRevocableEnabledLaneAlignmentEventAggregation", ttlField: "eventGeneratedAt", timeField: "eventGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
 
     // Conflict Monitor Assessments
     
@@ -153,6 +154,7 @@ const conflictMonitorCollections = [
     { name: "CmTimestampDeltaNotification", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmSpatTransitionNotification", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmEventStateProgressionNotification", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
+    { name: "CmRevocableEnabledLaneAlignmentNotification", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmNotification", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
 
     { name: "CmEventStateProgressionNotificationAggregation", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
@@ -161,9 +163,7 @@ const conflictMonitorCollections = [
     { name: "CmSignalStateConflictNotificationAggregation", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmTimeChangeDetailsNotificationAggregation", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
     { name: "CmSpatTimeChangeDetailsNotificationAggregation", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
-
-    
-
+    { name: "CmRevocableEnabledLaneAlignmentNotificationAggregation", ttlField: "notificationGeneratedAt", timeField: "notificationGeneratedAt", intersectionField: "intersectionID", expireTime: expireSeconds },
 
     // Reports
     { name: "CmReport", timeField: "reportGeneratedAt", intersectionField: "intersectionID"},


### PR DESCRIPTION
Adds in Connectors, MongoDB indexes and Topics for the following.

CmRevocableEnabledLaneAlignmentEvent
CmRevocableEnabledLaneAlignmentNotification
CmRevocableEnabledLaneAlignmentEventAggregation
CmRevocableEnabledLaneAlignmentNotificationAggregation

Note: the topics for CmRevocableEnabledLaneAlignment and CmRevocableEnabledLaneAlignmentNotification were already available. The CmRevocableEnabledLaneAlignment has been renamed to CmRevocableEnabledLaneAlignmentEvent to match the naming scheme of other events.