### PR TITLE
Adding required var collectionName to createAdditionalIndexes function

### DIFF
--- a/mongo/create_indexes.js
+++ b/mongo/create_indexes.js
@@ -445,6 +445,7 @@ function createGeoSpatialIndex(collection){
 }
 
 function createAdditionalIndexes(collection){
+    const collectionName = collection['name'];
     for (const additionalIndex of collection['additionalIndexes'] || []) {
         console.log("Creating additional index for " + collectionName + " with index: " + JSON.stringify(additionalIndex));
         const index_name = Object.entries(additionalIndex).map(([key, value]) => `${key}_${value}`).join("_");


### PR DESCRIPTION
It looks like the createAdditionalIndexes function is missing a variable definition for the variable collectionName. This makes the entire createIndexes script fail. We should probably hotfix this change into the release. This PR adds in the missing variable reference.